### PR TITLE
Introduce Azure naming module for resource naming (fixes #9)

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -1,5 +1,5 @@
 resource "azurerm_subnet" "aks" {
-  name                 = "aks"
+  name                 = module.naming.subnet.name
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [var.aks_subnet_address_prefix]
@@ -12,7 +12,7 @@ resource "azurerm_subnet_nat_gateway_association" "aks" {
 }
 
 resource "azurerm_user_assigned_identity" "aks" {
-  name                = "${var.name}-aks"
+  name                = "${module.naming.user_assigned_identity.name}-aks"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 }
@@ -24,7 +24,7 @@ resource "azurerm_role_assignment" "aks_network" {
 }
 
 resource "azurerm_kubernetes_cluster" "this" {
-  name                = var.name
+  name                = module.naming.kubernetes_cluster.name
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   dns_prefix          = var.name
@@ -96,7 +96,7 @@ resource "azurerm_role_assignment" "agic_identity_operator" {
 
 
 resource "azurerm_network_security_group" "aks" {
-  name                = "${var.name}-aks"
+  name                = "${module.naming.network_security_group.name}-aks"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 

--- a/aks.tf
+++ b/aks.tf
@@ -1,5 +1,5 @@
 resource "azurerm_subnet" "aks" {
-  name                 = module.naming.subnet.name
+  name                 = "${module.naming.subnet.name}-aks"
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [var.aks_subnet_address_prefix]

--- a/aks.tf
+++ b/aks.tf
@@ -82,7 +82,7 @@ resource "azurerm_role_assignment" "aks_agic_reader" {
 
 # Grant Contributor role on the Application Gateway to AGIC
 resource "azurerm_role_assignment" "aks_agic_contributor" {
-  scope                = "${azurerm_resource_group.this.id}/providers/Microsoft.Network/applicationGateways/${var.name}"
+  scope                = azurerm_application_gateway.this.id
   role_definition_name = "Contributor"
   principal_id         = azurerm_kubernetes_cluster.this.ingress_application_gateway[0].ingress_application_gateway_identity[0].object_id
 }

--- a/ingress.tf
+++ b/ingress.tf
@@ -16,7 +16,7 @@ EOT
 }
 
 resource "azurerm_subnet" "appgw" {
-  name                 = "appgw"
+  name                 = "${module.naming.subnet.name}-appgw"
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [var.app_gateway_subnet_address_prefix]
@@ -24,7 +24,7 @@ resource "azurerm_subnet" "appgw" {
 
 
 resource "azurerm_network_security_group" "appgw" {
-  name                = "${var.name}-appgw"
+  name                = "${module.naming.network_security_group.name}-appgw"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 }
@@ -96,7 +96,7 @@ resource "azurerm_subnet_network_security_group_association" "appgw" {
 
 # Create User Assigned Identity for Application Gateway
 resource "azurerm_user_assigned_identity" "appgw" {
-  name                = "${var.name}-appgw-identity"
+  name                = "${module.naming.user_assigned_identity.name}-appgw-identity"
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
 }
@@ -115,7 +115,7 @@ resource "azurerm_key_vault_access_policy" "appgw" {
 
 # Enable Azure Application Gateway Ingress Controller
 resource "azurerm_application_gateway" "this" {
-  name                = var.name
+  name                = module.naming.application_gateway.name
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
 
@@ -219,7 +219,7 @@ resource "azurerm_application_gateway" "this" {
 }
 
 resource "azurerm_public_ip" "appgw" {
-  name                = "${var.name}-appgw"
+  name                = "${module.naming.public_ip.name}-appgw"
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
   allocation_method   = "Static"

--- a/naming.tf
+++ b/naming.tf
@@ -1,0 +1,5 @@
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "0.4.2"
+  suffix  = [var.name]
+}

--- a/network.tf
+++ b/network.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_network" "this" {
-  name                = var.name
+  name                = module.naming.virtual_network.name
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   address_space       = [var.virtual_network_address_prefix]
@@ -16,14 +16,14 @@ resource "azurerm_virtual_network" "this" {
 resource "azurerm_network_ddos_protection_plan" "this" {
   count = var.use_ddos_protection ? 1 : 0
 
-  name                = var.name
+  name                = module.naming.network_ddos_protection_plan.name
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
 }
 
 # Add non-zonal NAT Gateway
 resource "azurerm_public_ip" "nat_gateway" {
-  name                = "${var.name}-nat-gw"
+  name                = "${module.naming.public_ip.name}-nat-gw"
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
   allocation_method   = "Static"
@@ -31,7 +31,7 @@ resource "azurerm_public_ip" "nat_gateway" {
 }
 
 resource "azurerm_nat_gateway" "this" {
-  name                = var.name
+  name                = module.naming.nat_gateway.name
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   sku_name            = "Standard"

--- a/postgres.tf
+++ b/postgres.tf
@@ -1,5 +1,5 @@
 resource "azurerm_subnet" "db" {
-  name                 = "db"
+  name                 = "${module.naming.subnet.name}db"
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [var.db_subnet_address_prefix]
@@ -17,7 +17,7 @@ resource "azurerm_subnet" "db" {
 }
 
 resource "azurerm_postgresql_flexible_server" "this" {
-  name                          = "${local.globally_unique_prefix}${var.name}"
+  name                          = module.naming.postgresql_server.unique_name
   resource_group_name           = azurerm_resource_group.this.name
   location                      = var.location
   version                       = "15"
@@ -62,7 +62,7 @@ resource "azurerm_postgresql_flexible_server" "this" {
 }
 
 resource "azurerm_postgresql_flexible_server_database" "langfuse" {
-  name      = "langfuse"
+  name      = module.naming.postgresql_database.name
   server_id = azurerm_postgresql_flexible_server.this.id
   charset   = "UTF8"
   collation = "en_US.utf8"
@@ -80,7 +80,7 @@ resource "random_password" "postgres_password" {
 
 # Add Private Endpoint for PostgreSQL
 resource "azurerm_private_endpoint" "postgres" {
-  name                = "${var.name}-postgres"
+  name                = "${module.naming.private_endpoint.name}-postgres"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   subnet_id           = azurerm_subnet.aks.id

--- a/postgres.tf
+++ b/postgres.tf
@@ -17,7 +17,7 @@ resource "azurerm_subnet" "db" {
 }
 
 resource "azurerm_postgresql_flexible_server" "this" {
-  name                          = module.naming.postgresql_server.unique_name
+  name                          = module.naming.postgresql_server.name_unique
   resource_group_name           = azurerm_resource_group.this.name
   location                      = var.location
   version                       = "15"

--- a/redis.tf
+++ b/redis.tf
@@ -1,5 +1,5 @@
 resource "azurerm_subnet" "redis" {
-  name                 = "redis"
+  name                 = "${module.naming.subnet.name}-redis"
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [var.redis_subnet_address_prefix]
@@ -7,7 +7,7 @@ resource "azurerm_subnet" "redis" {
 
 # Add Private Endpoint for Redis
 resource "azurerm_private_endpoint" "redis" {
-  name                = "${var.name}-redis"
+  name                = "${module.naming.private_endpoint.name}-redis"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   subnet_id           = azurerm_subnet.aks.id
@@ -43,7 +43,7 @@ resource "azurerm_private_dns_a_record" "redis" {
 }
 
 resource "azurerm_redis_cache" "this" {
-  name                          = "${local.globally_unique_prefix}${var.name}"
+  name                          = module.naming.redis_cache.unique_name
   location                      = var.location
   resource_group_name           = azurerm_resource_group.this.name
   capacity                      = var.redis_capacity

--- a/redis.tf
+++ b/redis.tf
@@ -43,7 +43,7 @@ resource "azurerm_private_dns_a_record" "redis" {
 }
 
 resource "azurerm_redis_cache" "this" {
-  name                          = module.naming.redis_cache.unique_name
+  name                          = module.naming.redis_cache.name_unique
   location                      = var.location
   resource_group_name           = azurerm_resource_group.this.name
   capacity                      = var.redis_capacity

--- a/resource-group.tf
+++ b/resource-group.tf
@@ -1,4 +1,4 @@
 resource "azurerm_resource_group" "this" {
-  name     = var.name
+  name     = module.naming.resource_group.name
   location = var.location
 }

--- a/storage.tf
+++ b/storage.tf
@@ -1,5 +1,5 @@
 resource "azurerm_subnet" "storage" {
-  name                 = "storage"
+  name                 = "${module.naming.subnet.name}-storage"
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [var.storage_subnet_address_prefix]
@@ -13,7 +13,7 @@ resource "azurerm_subnet_nat_gateway_association" "storage" {
 }
 
 resource "azurerm_storage_account" "this" {
-  name                     = "${local.globally_unique_prefix}${var.name}"
+  name                     = module.naming.storage_account.unique_name
   resource_group_name      = azurerm_resource_group.this.name
   location                 = azurerm_resource_group.this.location
   account_tier             = "Standard"
@@ -30,13 +30,13 @@ resource "azurerm_storage_account" "this" {
 }
 
 resource "azurerm_storage_container" "this" {
-  name                  = var.name
+  name                  = module.naming.storage_container.name
   storage_account_id    = azurerm_storage_account.this.id
   container_access_type = "private"
 }
 
 resource "azurerm_private_endpoint" "storage" {
-  name                = "${var.name}-storage"
+  name                = "${module.naming.private_endpoint.name}-storage"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   subnet_id           = azurerm_subnet.aks.id

--- a/storage.tf
+++ b/storage.tf
@@ -13,7 +13,7 @@ resource "azurerm_subnet_nat_gateway_association" "storage" {
 }
 
 resource "azurerm_storage_account" "this" {
-  name                     = module.naming.storage_account.unique_name
+  name                     = module.naming.storage_account.name_unique
   resource_group_name      = azurerm_resource_group.this.name
   location                 = azurerm_resource_group.this.location
   account_tier             = "Standard"

--- a/storage.tf
+++ b/storage.tf
@@ -13,7 +13,7 @@ resource "azurerm_subnet_nat_gateway_association" "storage" {
 }
 
 resource "azurerm_storage_account" "this" {
-  name                     = module.naming.storage_account.name_unique
+  name                     = replace(module.naming.storage_account.name_unique, "-", "")
   resource_group_name      = azurerm_resource_group.this.name
   location                 = azurerm_resource_group.this.location
   account_tier             = "Standard"

--- a/tls.tf
+++ b/tls.tf
@@ -8,13 +8,13 @@ resource "random_string" "key_vault_postfix" {
 }
 
 resource "azurerm_key_vault" "this" {
-  name                        = "${local.globally_unique_prefix}${var.name}${random_string.key_vault_postfix.result}"
-  location                    = azurerm_resource_group.this.location
-  resource_group_name         = azurerm_resource_group.this.name
-  tenant_id                   = data.azurerm_client_config.current.tenant_id
-  sku_name                    = "standard"
-  purge_protection_enabled    = true
-  soft_delete_retention_days  = 7
+  name                       = module.naming.key_vault.unique_name
+  location                   = azurerm_resource_group.this.location
+  resource_group_name        = azurerm_resource_group.this.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 7
 }
 
 resource "azurerm_key_vault_access_policy" "this" {
@@ -58,7 +58,7 @@ resource "azurerm_key_vault_access_policy" "this" {
 
 # Add Private Endpoint for Key Vault
 resource "azurerm_private_endpoint" "key_vault" {
-  name                = "${var.name}-keyvault"
+  name                = "${module.naming.private_endpoint.name}-keyvault"
   location            = azurerm_resource_group.this.location
   resource_group_name = azurerm_resource_group.this.name
   subnet_id           = azurerm_subnet.aks.id
@@ -94,7 +94,7 @@ resource "azurerm_private_dns_a_record" "key_vault" {
 }
 
 resource "azurerm_key_vault_certificate" "this" {
-  name         = var.name
+  name         = module.naming.key_vault_certificate.name
   key_vault_id = azurerm_key_vault.this.id
 
   certificate_policy {

--- a/tls.tf
+++ b/tls.tf
@@ -8,7 +8,7 @@ resource "random_string" "key_vault_postfix" {
 }
 
 resource "azurerm_key_vault" "this" {
-  name                       = module.naming.key_vault.unique_name
+  name                       = module.naming.key_vault.name_unique
   location                   = azurerm_resource_group.this.location
   resource_group_name        = azurerm_resource_group.this.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id


### PR DESCRIPTION
I've taken the liberty to switch all resource names to the Azure naming module. This enables the use of the Azure CAF naming conventions for all supported resources, as well as more straightforward unique names for the resources that require them.

In corporate environments, this works much better than static resource naming and will avoid complaints in tenants using Azure Policy to enforce the Azure CAF naming conventions.

Furthermore, this prevents issues with length restrictions, e.g. in Storage Accounts.

This would fix #9 .