### PR TITLE
fix: update output var names to reflect those in outputs.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,18 @@ module "langfuse" {
 }
 
 provider "kubernetes" {
-  host                   = module.langfuse.aks_cluster_host
-  client_certificate     = base64decode(module.langfuse.aks_cluster_client_certificate)
-  client_key             = base64decode(module.langfuse.aks_cluster_client_key)
-  cluster_ca_certificate = base64decode(module.langfuse.aks_cluster_ca_certificate)
+  host                   = module.langfuse.cluster_host
+  client_certificate     = base64decode(module.langfuse.cluster_client_certificate)
+  client_key             = base64decode(module.langfuse.cluster_client_key)
+  cluster_ca_certificate = base64decode(module.langfuse.cluster_ca_certificate)
 }
 
 provider "helm" {
   kubernetes {
-    host                   = module.langfuse.aks_cluster_host
-    client_certificate     = base64decode(module.langfuse.aks_cluster_client_certificate)
-    client_key             = base64decode(module.langfuse.aks_cluster_client_key)
-    cluster_ca_certificate = base64decode(module.langfuse.aks_cluster_ca_certificate)
+    host                   = module.langfuse.cluster_host
+    client_certificate     = base64decode(module.langfuse.cluster_client_certificate)
+    client_key             = base64decode(module.langfuse.cluster_client_key)
+    cluster_ca_certificate = base64decode(module.langfuse.cluster_ca_certificate)
   }
 }
 ```


### PR DESCRIPTION
**Changes:**
- Update README code to reflect the output var names correctly (in alignment with outputs.tf and examples/quickstart.tf)
- Example:  _module.langfuse.aks_cluster_host to module.langfuse.cluster_host_

**Why?**
- Accurate reflection of vars from outputs.tf
- Prevent cycle error on plan/apply terraform commands

**Note**
The code shown on the [website page](https://langfuse.com/self-hosting/azure) needs to be updated as well

