### PR TITLE
feat: md5 hash for creating global unique prefix from domain

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,9 @@
 locals {
   tag_name = lower(var.name) == "langfuse" ? "Langfuse" : "Langfuse ${var.name}"
 
-  # Convert domain to globally unique name format, supporting only lowercase letters and numbers (e.g., company.com -> companycom)
-  globally_unique_prefix = replace(lower(var.domain), ".", "")
+  # Convert domain to globally unique name format, supporting only lowercase letters and numbers 
+  # Supports naming convention required by azure resources used for this deployment
+  # MD5 substr enables traceability for domains used
+  # lf3 prefix helps identify langfuse v3 resource
+  globally_unique_prefix = "lf3${substr(md5(var.domain), 0, 6)}"
 }


### PR DESCRIPTION
This commit addresses the following issue:
 - Azure key vault and storage account names have a 24 character limit on them. Since the globally_unique_prefix in locals.tf depends on the domain name and is used in the naming process of storage account and key vault (and other resources) it puts a constraint on what domain name we use. Also when creating storage acc and key vault, the name of the resource group is also added. This makes using a domain name and resource group name of our choice difficult. 
 
Solution:
- A length 6 substring MD5 hash of the domain name (along with a "lf3" prefix to easily identify languse v3 resource). This helps keep the uniqueness and helps with traceability as well (since MD5 hashes are deterministic)

Note:
- Extra long resource group names can still cause the length issue (though is less likely with the above improvement), but that is not part of this feat/fix. 