### PR TITLE
Update storage.tf

### DIFF
--- a/storage.tf
+++ b/storage.tf
@@ -20,6 +20,7 @@ resource "azurerm_storage_account" "this" {
   account_replication_type = "GRS"
   min_tls_version          = "TLS1_2"
   public_network_access_enabled = false
+  allow_nested_items_to_be_public = false
 
   blob_properties {
     versioning_enabled = true


### PR DESCRIPTION
Added another option required for default Built-in Azure Policy which prevents Public Access to Storage to allow this deployment through. As this deployment uses PE there is no need for having any public access.