### PR TITLE
feat: add support for external Key Vault certificate

### DIFF
--- a/ingress.tf
+++ b/ingress.tf
@@ -154,7 +154,7 @@ resource "azurerm_application_gateway" "this" {
 
   ssl_certificate {
     name                = var.name
-    key_vault_secret_id = azurerm_key_vault_certificate.this.versionless_secret_id
+    key_vault_secret_id = local.ssl_certificate_secret_id
   }
 
   backend_address_pool {

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -1,5 +1,5 @@
 locals {
-  langfuse_values   = <<EOT
+  langfuse_values       = <<EOT
 langfuse:
   salt:
     secretKeyRef:
@@ -52,7 +52,7 @@ s3:
   mediaUpload:
     prefix: "media/"
 EOT
-  encryption_values = var.use_encryption_key == false ? "" : <<EOT
+  encryption_values     = var.use_encryption_key == false ? "" : <<EOT
 langfuse:
   encryptionKey:
     secretKeyRef:

--- a/locals.tf
+++ b/locals.tf
@@ -3,4 +3,7 @@ locals {
 
   # Convert domain to globally unique name format, supporting only lowercase letters and numbers (e.g., company.com -> companycom)
   globally_unique_prefix = replace(lower(var.domain), ".", "")
+
+  # Use external certificate secret ID if provided, otherwise use the self-signed certificate
+  ssl_certificate_secret_id = var.ssl_certificate_secret_id != null ? var.ssl_certificate_secret_id : azurerm_key_vault_certificate.this[0].versionless_secret_id
 }

--- a/tls.tf
+++ b/tls.tf
@@ -94,6 +94,8 @@ resource "azurerm_private_dns_a_record" "key_vault" {
 }
 
 resource "azurerm_key_vault_certificate" "this" {
+  count = var.ssl_certificate_secret_id == null ? 1 : 0
+
   name         = module.naming.key_vault_certificate.name
   key_vault_id = azurerm_key_vault.this.id
 
@@ -141,8 +143,8 @@ resource "azurerm_key_vault_certificate" "this" {
   }
 
   depends_on = [
-    azurerm_key_vault_access_policy.this, 
+    azurerm_key_vault_access_policy.this,
     azurerm_key_vault_access_policy.appgw,
     azurerm_dns_zone.this
-    ]
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -178,3 +178,9 @@ variable "additional_env" {
     error_message = "Each environment variable must have either 'value' or 'valueFrom' specified, but not both."
   }
 }
+
+variable "ssl_certificate_secret_id" {
+  description = "Azure Key Vault secret ID for an existing SSL certificate. If provided, the module will use this certificate instead of creating a self-signed one. The Application Gateway managed identity must have access to this Key Vault."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary

This PR adds support for using an external Azure Key Vault certificate instead of the self-signed certificate created by the module. This allows users to bring their own SSL certificates from their own Key Vault.

- Added `ssl_certificate_secret_id` variable to accept external certificate secret ID
- Made self-signed certificate creation conditional based on the variable
- Updated Application Gateway to use external or internal certificate via local variable
- Maintains full backward compatibility (defaults to self-signed certificate if not provided)

## Use Case

Users can now pass their own certificate from an external Key Vault:

```hcl
module "langfuse" {
  source = "..."
  ssl_certificate_secret_id = "https://my-keyvault.vault.azure.net/secrets/my-cert"
  # ... other variables
}
```

The Application Gateway managed identity must have appropriate access permissions to the external Key Vault (assumes it's already whitelisted).

## Testing

- ✅ Code formatted with `terraform fmt`
- ✅ Backward compatible - existing deployments will continue to work without changes
- ✅ When `ssl_certificate_secret_id` is provided, module uses external certificate
- ✅ When `ssl_certificate_secret_id` is null (default), module creates self-signed certificate

🤖 Generated with [Claude Code](https://claude.com/claude-code)