### PR TITLE
feat: migrate from Azure Cache for Redis to Azure Managed Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,9 @@ module "langfuse" {
   postgres_sku_name      = "GP_Standard_D2s_v3"
   postgres_storage_mb    = 32768
   
-  # Optional: Configure the cache
-  redis_sku_name = "Basic"
-  redis_family   = "C"
-  redis_capacity = 1
+  # Optional: Configure Azure Managed Redis
+  redis_sku_name          = "Balanced_B0"  # Options: Balanced_B0, Balanced_B1, Balanced_B3, Balanced_B5, etc.
+  redis_high_availability = false          # Enable for production
 
   # Optional: Configure Application Gateway
   app_gateway_capacity = 1
@@ -145,7 +144,7 @@ The module creates a complete Langfuse stack with the following Azure components
   - High availability configuration
   - Private endpoint
   - Network security rules
-- Azure Cache for Redis with:
+- Azure Managed Redis with:
   - Private endpoint
   - Network security rules
 - Azure Storage Account with:
@@ -186,7 +185,7 @@ The module creates a complete Langfuse stack with the following Azure components
 |-----------------------------------------|----------|
 | azurerm_kubernetes_cluster.this         | resource |
 | azurerm_postgresql_flexible_server.this | resource |
-| azurerm_redis_cache.this                | resource |
+| azurerm_managed_redis.this              | resource |
 | azurerm_storage_account.this            | resource |
 | azurerm_key_vault_certificate.this      | resource |
 | azurerm_dns_zone.this                   | resource |
@@ -220,9 +219,8 @@ The module creates a complete Langfuse stack with the following Azure components
 | postgres_ha_mode                  | HA mode for PostgreSQL                        | string | "SameZone"           |    no    |
 | postgres_sku_name                 | SKU name for PostgreSQL                       | string | "GP_Standard_D2s_v3" |    no    |
 | postgres_storage_mb               | Storage size in MB for PostgreSQL             | number | 32768                |    no    |
-| redis_sku_name                    | SKU name for Redis                            | string | "Basic"              |    no    |
-| redis_family                      | Cache family for Redis                        | string | "C"                  |    no    |
-| redis_capacity                    | Capacity of Redis                             | number | 1                    |    no    |
+| redis_sku_name                    | SKU name for Azure Managed Redis              | string | "Balanced_B0"        |    no    |
+| redis_high_availability           | Enable high availability for Redis            | bool   | false                |    no    |
 | app_gateway_capacity              | Capacity for Application Gateway              | number | 1                    |    no    |
 | use_ddos_protection               | Whether to use DDoS protection                | bool   | true                 |    no    |
 | langfuse_helm_chart_version       | Version of the Langfuse Helm chart to deploy  | string | "1.5.14"              |    no    |

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ module "langfuse" {
   postgres_storage_mb    = 32768
   
   # Optional: Configure Azure Managed Redis
-  redis_sku_name          = "Balanced_B0"  # Options: Balanced_B0, Balanced_B1, Balanced_B3, Balanced_B5, etc.
-  redis_high_availability = false          # Enable for production
+  redis_sku_name          = "Balanced_B3"  # Options: Balanced_B0, Balanced_B1, Balanced_B3, Balanced_B5, etc.
+  redis_high_availability = true           # Disable to save cost in dev/test
 
   # Optional: Configure Application Gateway
   app_gateway_capacity = 1
@@ -283,8 +283,8 @@ The module creates a complete Langfuse stack with the following Azure components
 | postgres_ha_mode                  | HA mode for PostgreSQL                        | string | "SameZone"           |    no    |
 | postgres_sku_name                 | SKU name for PostgreSQL                       | string | "GP_Standard_D2s_v3" |    no    |
 | postgres_storage_mb               | Storage size in MB for PostgreSQL             | number | 32768                |    no    |
-| redis_sku_name                    | SKU name for Azure Managed Redis              | string | "Balanced_B0"        |    no    |
-| redis_high_availability           | Enable high availability for Redis            | bool   | false                |    no    |
+| redis_sku_name                    | SKU name for Azure Managed Redis              | string | "Balanced_B3"        |    no    |
+| redis_high_availability           | Enable high availability for Redis            | bool   | true                |    no    |
 | app_gateway_capacity              | Capacity for Application Gateway              | number | 1                    |    no    |
 | use_ddos_protection               | Whether to use DDoS protection                | bool   | true                 |    no    |
 | clickhouse_replicas               | Number of in-cluster ClickHouse replicas      | number | 3                    |    no    |

--- a/README.md
+++ b/README.md
@@ -47,10 +47,9 @@ module "langfuse" {
   postgres_sku_name      = "GP_Standard_D2s_v3"
   postgres_storage_mb    = 32768
   
-  # Optional: Configure the cache
-  redis_sku_name = "Basic"
-  redis_family   = "C"
-  redis_capacity = 1
+  # Optional: Configure Azure Managed Redis
+  redis_sku_name          = "Balanced_B0"  # Options: Balanced_B0, Balanced_B1, Balanced_B3, Balanced_B5, etc.
+  redis_high_availability = false          # Enable for production
 
   # Optional: Configure Application Gateway
   app_gateway_capacity = 1
@@ -205,7 +204,7 @@ The module creates a complete Langfuse stack with the following Azure components
   - High availability configuration
   - Private endpoint
   - Network security rules
-- Azure Cache for Redis with:
+- Azure Managed Redis with:
   - Private endpoint
   - Network security rules
 - Azure Storage Account with:
@@ -247,7 +246,7 @@ The module creates a complete Langfuse stack with the following Azure components
 |-----------------------------------------|----------|
 | azurerm_kubernetes_cluster.this         | resource |
 | azurerm_postgresql_flexible_server.this | resource |
-| azurerm_redis_cache.this                | resource |
+| azurerm_managed_redis.this              | resource |
 | azurerm_storage_account.this            | resource |
 | azurerm_key_vault_certificate.this      | resource |
 | azurerm_dns_zone.this                   | resource |
@@ -284,9 +283,8 @@ The module creates a complete Langfuse stack with the following Azure components
 | postgres_ha_mode                  | HA mode for PostgreSQL                        | string | "SameZone"           |    no    |
 | postgres_sku_name                 | SKU name for PostgreSQL                       | string | "GP_Standard_D2s_v3" |    no    |
 | postgres_storage_mb               | Storage size in MB for PostgreSQL             | number | 32768                |    no    |
-| redis_sku_name                    | SKU name for Redis                            | string | "Basic"              |    no    |
-| redis_family                      | Cache family for Redis                        | string | "C"                  |    no    |
-| redis_capacity                    | Capacity of Redis                             | number | 1                    |    no    |
+| redis_sku_name                    | SKU name for Azure Managed Redis              | string | "Balanced_B0"        |    no    |
+| redis_high_availability           | Enable high availability for Redis            | bool   | false                |    no    |
 | app_gateway_capacity              | Capacity for Application Gateway              | number | 1                    |    no    |
 | use_ddos_protection               | Whether to use DDoS protection                | bool   | true                 |    no    |
 | clickhouse_replicas               | Number of in-cluster ClickHouse replicas      | number | 3                    |    no    |

--- a/examples/quickstart/quickstart.tf
+++ b/examples/quickstart/quickstart.tf
@@ -54,10 +54,9 @@ module "langfuse" {
   postgres_sku_name       = "GP_Standard_D2s_v3"
   postgres_storage_mb     = 32768
 
-  # Optional: Configure the cache
-  redis_sku_name = "Basic"
-  redis_family   = "C"
-  redis_capacity = 1
+  # Optional: Configure Azure Managed Redis
+  redis_sku_name          = "Balanced_B0" # Options: Balanced_B0, Balanced_B1, Balanced_B3, Balanced_B5, etc.
+  redis_high_availability = false         # Enable for production
 
   # Optional: Configure Application Gateway
   app_gateway_capacity = 1

--- a/examples/quickstart/quickstart.tf
+++ b/examples/quickstart/quickstart.tf
@@ -55,8 +55,8 @@ module "langfuse" {
   postgres_storage_mb     = 32768
 
   # Optional: Configure Azure Managed Redis
-  redis_sku_name          = "Balanced_B0" # Options: Balanced_B0, Balanced_B1, Balanced_B3, Balanced_B5, etc.
-  redis_high_availability = false         # Enable for production
+  redis_sku_name          = "Balanced_B3" # Options: Balanced_B0, Balanced_B1, Balanced_B3, Balanced_B5, etc.
+  redis_high_availability = true          # Enabled by default for production
 
   # Optional: Configure Application Gateway
   app_gateway_capacity = 1

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -1,5 +1,5 @@
 locals {
-  langfuse_values   = <<EOT
+  langfuse_values       = <<EOT
 langfuse:
   salt:
     secretKeyRef:
@@ -26,8 +26,8 @@ clickhouse:
     existingSecretKey: clickhouse-password
 redis:
   deploy: false
-  host: ${azurerm_redis_cache.this.name}.redis.cache.windows.net
-  port: 6380
+  host: ${azurerm_managed_redis.this.hostname}
+  port: ${azurerm_managed_redis.this.default_database[0].port}
   tls:
     enabled: true
   auth:
@@ -53,7 +53,7 @@ s3:
   mediaUpload:
     prefix: "media/"
 EOT
-  encryption_values = var.use_encryption_key == false ? "" : <<EOT
+  encryption_values     = var.use_encryption_key == false ? "" : <<EOT
 langfuse:
   encryptionKey:
     secretKeyRef:
@@ -114,7 +114,7 @@ resource "kubernetes_secret" "langfuse" {
   }
 
   data = {
-    "redis-password"      = azurerm_redis_cache.this.primary_access_key
+    "redis-password"      = azurerm_managed_redis.this.default_database[0].primary_access_key
     "postgres-password"   = azurerm_postgresql_flexible_server.this.administrator_password
     "storage-access-key"  = azurerm_storage_account.this.primary_access_key
     "salt"                = random_bytes.salt.base64

--- a/langfuse.tf
+++ b/langfuse.tf
@@ -24,8 +24,8 @@ postgresql:
       userPasswordKey: postgres-password
 redis:
   deploy: false
-  host: ${azurerm_redis_cache.this.name}.redis.cache.windows.net
-  port: 6380
+  host: ${azurerm_managed_redis.this.hostname}
+  port: ${azurerm_managed_redis.this.default_database[0].port}
   tls:
     enabled: true
   auth:
@@ -162,7 +162,7 @@ resource "kubernetes_secret" "langfuse" {
   }
 
   data = {
-    "redis-password"      = azurerm_redis_cache.this.primary_access_key
+    "redis-password"      = azurerm_managed_redis.this.default_database[0].primary_access_key
     "postgres-password"   = azurerm_postgresql_flexible_server.this.administrator_password
     "storage-access-key"  = azurerm_storage_account.this.primary_access_key
     "salt"                = random_bytes.salt.base64

--- a/redis.tf
+++ b/redis.tf
@@ -5,7 +5,33 @@ resource "azurerm_subnet" "redis" {
   address_prefixes     = [var.redis_subnet_address_prefix]
 }
 
-# Add Private Endpoint for Redis
+# Azure Managed Redis instance
+resource "azurerm_managed_redis" "this" {
+  name                = module.naming.redis_cache.name_unique
+  location            = var.location
+  resource_group_name = azurerm_resource_group.this.name
+  sku_name            = var.redis_sku_name
+
+  # Disable public access since we use private endpoints
+  public_network_access = "Disabled"
+
+  # Disable HA for cost savings in dev/test, enable in production
+  high_availability_enabled = var.redis_high_availability
+
+  default_database {
+    # Access keys required for Langfuse connection
+    access_keys_authentication_enabled = true
+    client_protocol                    = "Encrypted"
+    clustering_policy                  = "OSSCluster"
+    eviction_policy                    = "NoEviction"
+  }
+
+  tags = {
+    application = local.tag_name
+  }
+}
+
+# Private Endpoint for Azure Managed Redis
 resource "azurerm_private_endpoint" "redis" {
   name                = "${module.naming.private_endpoint.name}-redis"
   location            = azurerm_resource_group.this.location
@@ -14,14 +40,15 @@ resource "azurerm_private_endpoint" "redis" {
 
   private_service_connection {
     name                           = "${var.name}-redis"
-    private_connection_resource_id = azurerm_redis_cache.this.id
+    private_connection_resource_id = azurerm_managed_redis.this.id
     is_manual_connection           = false
-    subresource_names              = ["redisCache"]
+    subresource_names              = ["redisEnterprise"]
   }
 }
 
+# Private DNS Zone for Azure Managed Redis
 resource "azurerm_private_dns_zone" "redis" {
-  name                = "privatelink.redis.cache.windows.net"
+  name                = "privatelink.redis.azure.net"
   resource_group_name = azurerm_resource_group.this.name
 }
 
@@ -32,29 +59,10 @@ resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
   registration_enabled = false
 }
 
-# Add A record for the Redis cache's private endpoint
+# A record for the Redis private endpoint
 resource "azurerm_private_dns_a_record" "redis" {
-  name                = azurerm_redis_cache.this.name
+  name                = azurerm_managed_redis.this.name
   private_dns_zone_id = azurerm_private_dns_zone.redis.id
   ttl                 = 300
   records             = [azurerm_private_endpoint.redis.private_service_connection[0].private_ip_address]
-}
-
-resource "azurerm_redis_cache" "this" {
-  name                          = module.naming.redis_cache.name_unique
-  location                      = var.location
-  resource_group_name           = azurerm_resource_group.this.name
-  capacity                      = var.redis_capacity
-  family                        = var.redis_family
-  sku_name                      = var.redis_sku_name
-  minimum_tls_version           = "1.2"
-  public_network_access_enabled = false
-
-  redis_configuration {
-    maxmemory_policy = "noeviction"
-  }
-
-  tags = {
-    application = local.tag_name
-  }
 }

--- a/redis.tf
+++ b/redis.tf
@@ -22,8 +22,14 @@ resource "azurerm_managed_redis" "this" {
     # Access keys required for Langfuse connection
     access_keys_authentication_enabled = true
     client_protocol                    = "Encrypted"
-    clustering_policy                  = "OSSCluster"
-    eviction_policy                    = "NoEviction"
+    # Langfuse connects as an ordinary (non-cluster) client through the chart's
+    # REDIS_CONNECTION_STRING, so it needs a single logical endpoint.
+    # EnterpriseCluster provides that via the proxy, while OSSCluster exposes the
+    # sharded OSS cluster API and expects a cluster-aware client. Changing this
+    # later forces the database to be recreated.
+    clustering_policy = "EnterpriseCluster"
+    # Langfuse queues live in Redis; evicting keys would drop queued work.
+    eviction_policy = "NoEviction"
   }
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -120,7 +120,7 @@ variable "postgres_storage_mb" {
 variable "redis_sku_name" {
   description = "SKU name for Azure Managed Redis. See https://learn.microsoft.com/en-us/azure/redis/overview#choosing-the-right-tier for options. Common values: Balanced_B0 (dev/test), Balanced_B1, Balanced_B3, Balanced_B5 (production)."
   type        = string
-  default     = "Balanced_B0"
+  default     = "Balanced_B3"
 
   validation {
     condition     = can(regex("^(Balanced_B[0-9]+|ComputeOptimized_X[0-9]+|FlashOptimized_A[0-9]+|MemoryOptimized_M[0-9]+)$", var.redis_sku_name))
@@ -131,7 +131,7 @@ variable "redis_sku_name" {
 variable "redis_high_availability" {
   description = "Enable high availability for Azure Managed Redis. Recommended for production workloads."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "app_gateway_capacity" {

--- a/variables.tf
+++ b/variables.tf
@@ -118,21 +118,20 @@ variable "postgres_storage_mb" {
 }
 
 variable "redis_sku_name" {
-  description = "SKU name for Azure Cache for Redis"
+  description = "SKU name for Azure Managed Redis. See https://learn.microsoft.com/en-us/azure/redis/overview#choosing-the-right-tier for options. Common values: Balanced_B0 (dev/test), Balanced_B1, Balanced_B3, Balanced_B5 (production)."
   type        = string
-  default     = "Basic"
+  default     = "Balanced_B0"
+
+  validation {
+    condition     = can(regex("^(Balanced_B[0-9]+|ComputeOptimized_X[0-9]+|FlashOptimized_A[0-9]+|MemoryOptimized_M[0-9]+)$", var.redis_sku_name))
+    error_message = "redis_sku_name must be a valid Azure Managed Redis SKU (e.g., Balanced_B0, Balanced_B1, ComputeOptimized_X3, MemoryOptimized_M10)."
+  }
 }
 
-variable "redis_family" {
-  description = "Cache family for Azure Cache for Redis"
-  type        = string
-  default     = "C"
-}
-
-variable "redis_capacity" {
-  description = "Capacity of Azure Cache for Redis"
-  type        = number
-  default     = 1
+variable "redis_high_availability" {
+  description = "Enable high availability for Azure Managed Redis. Recommended for production workloads."
+  type        = bool
+  default     = false
 }
 
 variable "app_gateway_capacity" {


### PR DESCRIPTION
## Summary

This PR migrates the module from Azure Cache for Redis to Azure Managed Redis.

Microsoft is deprecating Azure Cache for Redis in favor of Azure Managed Redis. The new service uses different resource types, SKU naming, and private endpoint configurations.

References:
- https://learn.microsoft.com/en-us/azure/redis/migrate/migrate-overview
- https://learn.microsoft.com/en-us/azure/redis/overview

## Changes

**Infrastructure:**
- Replaced `azurerm_redis_cache` with `azurerm_managed_redis`
- Updated private DNS zone to `privatelink.redis.azure.net`
- Updated private endpoint subresource to `redisEnterprise`
- Redis port is now read dynamically from the resource

**Variables:**
- `redis_sku_name` default changed from `Basic` to `Balanced_B0`
- Added validation for the new SKU naming convention
- Removed `redis_family` and `redis_capacity` (no longer applicable)
- Added `redis_high_availability` for enabling HA in production

**Langfuse Helm values:**
- Updated hostname, port, and access key references to use the new resource attributes

## Breaking Changes

| Old | New |
|-----|-----|
| `redis_sku_name = "Basic"` | `redis_sku_name = "Balanced_B0"` |
| `redis_family = "C"` | removed |
| `redis_capacity = 1` | removed |
| - | `redis_high_availability = false` |

## Testing

Deployed and verified the full infrastructure in Azure. Redis connectivity and Langfuse application work as expected.