### PR TITLE
feat: switch KeyVault from access policies to RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This module aims to provide a production-ready, secure, and scalable deployment 
 
 1. Set up the module with the settings that suit your needs. A minimal installation requires a `domain` which is under your control and a `resource_group_name`. Configure the kubernetes and helm providers to connect to the AKS cluster.
 
+> [!IMPORTANT]
+> The Key Vault is secured with Azure RBAC and this module creates the role assignments itself, so the identity running `terraform apply` needs `Microsoft.Authorization/roleAssignments/write` on the target scope — the built-in **Owner** or **User Access Administrator** role. Contributor alone is not sufficient.
+
 ```hcl
 module "langfuse" {
   source = "github.com/langfuse/langfuse-terraform-azure?ref=0.4.5"
@@ -166,7 +169,7 @@ The module creates a complete Langfuse stack with the following Azure components
 | Name       | Version |
 |------------|---------|
 | terraform  | >= 1.0  |
-| azurerm    | >= 3.0  |
+| azurerm    | >= 4.0  |
 | kubernetes | >= 2.10 |
 | helm       | >= 2.5  |
 
@@ -174,11 +177,12 @@ The module creates a complete Langfuse stack with the following Azure components
 
 | Name       | Version |
 |------------|---------|
-| azurerm    | >= 3.0  |
+| azurerm    | >= 4.0  |
 | kubernetes | >= 2.10 |
 | helm       | >= 2.5  |
 | random     | >= 3.0  |
 | tls        | >= 3.0  |
+| time       | >= 0.9  |
 
 ## Resources
 

--- a/ingress.tf
+++ b/ingress.tf
@@ -101,16 +101,11 @@ resource "azurerm_user_assigned_identity" "appgw" {
   location            = azurerm_resource_group.this.location
 }
 
-# Grant the identity access to the Key Vault
-resource "azurerm_key_vault_access_policy" "appgw" {
-  key_vault_id = azurerm_key_vault.this.id
-  tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = azurerm_user_assigned_identity.appgw.principal_id
-
-  secret_permissions = [
-    "Get",
-    "List"
-  ]
+# Grant the Application Gateway identity "Key Vault Secrets User" role to read certificates
+resource "azurerm_role_assignment" "keyvault_secrets_user" {
+  scope                = azurerm_key_vault.this.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.appgw.principal_id
 }
 
 # Enable Azure Application Gateway Ingress Controller

--- a/ingress.tf
+++ b/ingress.tf
@@ -106,6 +106,10 @@ resource "azurerm_role_assignment" "keyvault_secrets_user" {
   scope                = azurerm_key_vault.this.id
   role_definition_name = "Key Vault Secrets User"
   principal_id         = azurerm_user_assigned_identity.appgw.principal_id
+
+  # The identity is created in this same apply, so skip the directory lookup
+  # that would otherwise fail while Entra ID replicates the new principal.
+  skip_service_principal_aad_check = true
 }
 
 # Enable Azure Application Gateway Ingress Controller

--- a/tls.tf
+++ b/tls.tf
@@ -15,45 +15,14 @@ resource "azurerm_key_vault" "this" {
   sku_name                   = "standard"
   purge_protection_enabled   = true
   soft_delete_retention_days = 7
+  rbac_authorization_enabled = true
 }
 
-resource "azurerm_key_vault_access_policy" "this" {
-  key_vault_id = azurerm_key_vault.this.id
-  tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = data.azurerm_client_config.current.object_id
-
-  certificate_permissions = [
-    "Create",
-    "Delete",
-    "DeleteIssuers",
-    "Get",
-    "GetIssuers",
-    "Import",
-    "List",
-    "ListIssuers",
-    "ManageContacts",
-    "ManageIssuers",
-    "SetIssuers",
-    "Update",
-  ]
-
-  key_permissions = [
-    "Create",
-    "Delete",
-    "Get",
-    "Import",
-    "List",
-    "Update",
-  ]
-
-  secret_permissions = [
-    "Delete",
-    "Get",
-    "List",
-    "Purge",
-    "Recover",
-    "Set",
-  ]
+# Grant the Terraform deployer "Key Vault Certificates Officer" role for certificate management
+resource "azurerm_role_assignment" "keyvault_certificates_officer" {
+  scope                = azurerm_key_vault.this.id
+  role_definition_name = "Key Vault Certificates Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
 }
 
 # Add Private Endpoint for Key Vault
@@ -141,8 +110,8 @@ resource "azurerm_key_vault_certificate" "this" {
   }
 
   depends_on = [
-    azurerm_key_vault_access_policy.this,
-    azurerm_key_vault_access_policy.appgw,
+    azurerm_role_assignment.keyvault_certificates_officer,
+    azurerm_role_assignment.keyvault_secrets_user,
     azurerm_dns_zone.this
   ]
 }

--- a/tls.tf
+++ b/tls.tf
@@ -25,6 +25,19 @@ resource "azurerm_role_assignment" "keyvault_certificates_officer" {
   principal_id         = data.azurerm_client_config.current.object_id
 }
 
+# Role assignments are eventually consistent: the Key Vault data plane keeps
+# rejecting requests for a while after an assignment is created, so creating the
+# certificate right away fails with a 403. depends_on only orders the calls, it
+# does not wait for the assignment to take effect.
+resource "time_sleep" "key_vault_rbac_propagation" {
+  create_duration = "60s"
+
+  depends_on = [
+    azurerm_role_assignment.keyvault_certificates_officer,
+    azurerm_role_assignment.keyvault_secrets_user,
+  ]
+}
+
 # Add Private Endpoint for Key Vault
 resource "azurerm_private_endpoint" "key_vault" {
   name                = "${module.naming.private_endpoint.name}-keyvault"
@@ -110,8 +123,7 @@ resource "azurerm_key_vault_certificate" "this" {
   }
 
   depends_on = [
-    azurerm_role_assignment.keyvault_certificates_officer,
-    azurerm_role_assignment.keyvault_secrets_user,
+    time_sleep.key_vault_rbac_propagation,
     azurerm_dns_zone.this
   ]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,10 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      # azurerm 5.x removed arguments this module still uses
+      # 4.0 is the floor because rbac_authorization_enabled replaced
+      # enable_rbac_authorization there. azurerm 5.x removed arguments this module still uses
       # (e.g. azurerm_subnet.service_endpoints, private_dns_zone_name on
       # azurerm_private_dns_zone_virtual_network_link)
-      version = ">= 3.0.0, < 5.0.0"
+      version = ">= 4.0.0, < 5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -24,6 +25,10 @@ terraform {
     tls = {
       source  = "hashicorp/tls"
       version = ">= 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR migrates Azure KeyVault access control from the legacy access policy model to Azure RBAC, which is Microsoft's recommended approach for new deployments.

### Changes

- Enable `rbac_authorization_enabled` on the KeyVault resource
- Replace deployer access policy with `Key Vault Certificates Officer` role (least privilege for certificate management)
- Replace Application Gateway access policy with `Key Vault Secrets User` role (read-only access for SSL termination)
- Update certificate resource dependencies to use the new role assignments

### Why RBAC

- Unified access control model across Azure services
- Better security posture with separation of duties
- Integration with Privileged Identity Management (PIM)
- RBAC will become the default in Azure API version 2026-02-01

### Breaking Change

Existing deployments using access policies will need to either:
1. Recreate the KeyVault (recommended for clean state)
2. Manually migrate following [Microsoft's migration guide](https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-migration)

### Testing

Deployed and tested successfully in Sweden Central region with full infrastructure stack (AKS, PostgreSQL, Redis, Application Gateway).

Closes #26