### PR TITLE
fix: give the namespace a single owner and a real dependency

### DIFF
--- a/langfuse.tf
+++ b/langfuse.tf
@@ -158,7 +158,7 @@ resource "random_bytes" "encryption_key" {
 resource "kubernetes_secret" "langfuse" {
   metadata {
     name      = "langfuse"
-    namespace = "langfuse"
+    namespace = kubernetes_namespace.langfuse.metadata[0].name
   }
 
   data = {
@@ -173,12 +173,11 @@ resource "kubernetes_secret" "langfuse" {
 }
 
 resource "helm_release" "langfuse" {
-  name             = "langfuse"
-  repository       = "https://langfuse.github.io/langfuse-k8s"
-  version          = var.langfuse_helm_chart_version
-  chart            = "langfuse"
-  namespace        = "langfuse"
-  create_namespace = true
+  name       = "langfuse"
+  repository = "https://langfuse.github.io/langfuse-k8s"
+  version    = var.langfuse_helm_chart_version
+  chart      = "langfuse"
+  namespace  = kubernetes_namespace.langfuse.metadata[0].name
 
   values = [
     local.langfuse_values,


### PR DESCRIPTION
Answers "can we just use `create_namespace` instead of the dedicated resource?" — it turns out **no**, and looking into it surfaced a latent bug.

## Why `create_namespace` alone cannot work here

The module creates `kubernetes_secret.langfuse` (Postgres password, Redis key, storage key, salt, nextauth secret, encryption key) **in that namespace, before the Helm release**, because the chart consumes it via `existingSecret`. Helm only creates the namespace when it installs the release, so relying on `create_namespace` would mean the secret is created into a namespace that does not exist yet. The namespace therefore has to be a Terraform resource; the redundant part is `create_namespace`, not the resource.

## The latent bug

The namespace was effectively created three ways at once — the `kubernetes_namespace` resource, `create_namespace = true` on the release, and literal `"langfuse"` strings in both the secret and the release. Because those were **literals rather than references**, Terraform saw *no dependency* between the namespace and the secret that must live in it, and was free to create them in parallel. A fresh apply can fail with `namespaces "langfuse" not found`.

`terraform graph` before this change has no edge between the two; after it:

```
"[root] kubernetes_secret.langfuse (expand)" -> "[root] kubernetes_namespace.langfuse (expand)"
```

## Change

- Secret and release both reference `kubernetes_namespace.langfuse.metadata[0].name`.
- `create_namespace` dropped — Terraform owns the namespace, including on destroy.
- This is exactly what the GCP module already does, so the two modules now agree.

No variables change, and the rendered resources are identical for an existing deployment — the namespace is already Terraform-managed, so this only adds ordering.

## Test plan

- [x] `fmt -check` clean, `validate` green, and the new dependency edge confirmed in `terraform graph`.
- [ ] Ordering on a genuinely fresh apply is the thing a live run would confirm; the failure it prevents is intermittent by nature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)