### PR TITLE
ci: release the versions the weekly check bumps

### DIFF
--- a/.github/workflows/update-langfuse-versions.yml
+++ b/.github/workflows/update-langfuse-versions.yml
@@ -58,6 +58,17 @@ jobs:
           bump "$CHART" "$CHART_LATEST"
           bump "$APP" "$APP_LATEST"
 
+          # A bump that is never released does not reach anyone pinning a tag, so
+          # release it too. Only minor and patch updates: a major upstream bump
+          # needs a deliberately chosen module version.
+          REF=$(grep -oE '\?ref=[^"]+' README.md | head -1 | cut -d= -f2)
+          RELEASE="Leaving the module version alone, because a major upstream bump needs a deliberate one. Run the release workflow after merging."
+          if [ "${CHART%%.*}" = "${CHART_LATEST%%.*}" ] && [ "${APP%%.*}" = "${APP_LATEST%%.*}" ]; then
+            NEXT="${REF%.*}.$(( ${REF##*.} + 1 ))"
+            OLD="$REF" NEW="$NEXT" perl -pi -e 's{\?ref=\Q$ENV{OLD}\E\b}{?ref=$ENV{NEW}}g' README.md
+            RELEASE="Merging this releases \`$NEXT\`."
+          fi
+
           cat > "$RUNNER_TEMP/body.md" <<EOF
           | Component | From | To |
           | --- | --- | --- |
@@ -65,6 +76,8 @@ jobs:
           | Langfuse | \`$APP\` | [\`$APP_LATEST\`](https://github.com/langfuse/langfuse/releases/tag/v$APP_LATEST) |
 
           Rows where both versions match are unchanged. Read the linked release notes before merging: a major bump can need migration steps.
+
+          $RELEASE
 
           Opened by the weekly version check. Pull requests created with \`GITHUB_TOKEN\` do not trigger \`ci.yml\`, so close and reopen this one to run the checks.
           EOF


### PR DESCRIPTION
Same gap as langfuse-terraform-gcp#39, same 13-line fix — but **do not merge this until 1.0.0 is tagged.**

## Why it has to wait

`main` currently has **5 unreleased commits**, two of them breaking (#37 chart v2 / Langfuse v4, #35 Key Vault RBAC), while the README still documents `0.4.5`. I ran the patched workflow against `main` as it stands, and it does exactly the wrong thing:

```
README ref -> 0.4.6
body says: Merging this releases `0.4.6`.
```

That would publish chart v2, Langfuse v4 and the RBAC switch as a **patch** release. Once `1.0.0` exists the same logic is correct, and subsequent updates become `1.0.1`, `1.0.2`, and so on.

Leaving this open in the meantime is safe: Monday's run uses the workflow on `main`, which has no ref bump, so it will just open the usual version pull request (app `4.14.0 → 4.17.0` — upstream moved again) without touching the module version.

## Suggested order

1. Finish the v1 work — azurerm 5 migration, then #34.
2. Run the release workflow for `1.0.0`.
3. Merge this.

## The change

Identical to the GCP one, and the script variables already match this repo (`langfuse_helm_chart_version`):

- minor/patch upstream update → bump the module patch, merging tags and publishes it;
- major upstream bump → leave the module version alone and say so in the PR body.

## Test plan

- [x] YAML parses; the `run` block passes `bash -n`.
- [x] Dry-run against this repo produced the `0.4.6` result quoted above — which is the evidence for the ordering constraint, not a passing test.
- [x] Both paths already verified on the GCP module before it was ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)