### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Requests a review from @Steffen911 on every pull request, so community
+# contributions and the automated version bumps all surface in one place.
+* @Steffen911


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with a single global rule:

```
* @Steffen911
```

GitHub then requests your review automatically on every pull request that touches owned files — which is all of them — so community contributions and the automated weekly Langfuse version bumps show up under **Review requested** instead of having to be found.

Worth knowing about the semantics:

- It creates a **review request**, not an assignee. Discovery works the same way (notification plus the `review-requested:@me` filter), but the Assignees box stays empty.
- **GitHub never requests a review from the pull request author**, so this has no effect on pull requests you open yourself. It applies to community contributions and to the `github-actions[bot]` version-bump pull requests.
- It is **not blocking**: `require_code_owner_reviews` is `false` in this repo's branch protection, so merges are not gated by it. If you want it enforced, that is a separate branch-protection toggle rather than a change to this file.
- Code owners need write access to be requested, which you have (admin).

If a team would age better than a personal handle, `* @langfuse/<team>` is a one-line change — I used your handle because that is what you asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)