### PR TITLE
feat!: migrate to azurerm 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The module creates a complete Langfuse stack with the following Azure components
 | Name       | Version |
 |------------|---------|
 | terraform  | >= 1.3  |
-| azurerm    | >= 4.0  |
+| azurerm    | >= 5.0  |
 | kubernetes | >= 2.10 |
 | helm       | >= 2.7  |
 
@@ -234,7 +234,7 @@ The module creates a complete Langfuse stack with the following Azure components
 
 | Name       | Version |
 |------------|---------|
-| azurerm    | >= 4.0  |
+| azurerm    | >= 5.0  |
 | kubernetes | >= 2.10 |
 | helm       | >= 2.7  |
 | random     | >= 3.0  |

--- a/aks.tf
+++ b/aks.tf
@@ -30,6 +30,13 @@ resource "azurerm_kubernetes_cluster" "this" {
   dns_prefix          = var.name
   kubernetes_version  = var.kubernetes_version
 
+  # azurerm 5 requires this block. Manual keeps the cluster on the manually
+  # managed default_node_pool below, which is Azure's default and what this
+  # module has always used; Auto would hand node sizing to node auto-provisioning.
+  node_provisioning_profile {
+    mode = "Manual"
+  }
+
   default_node_pool {
     name                        = "default"
     vm_size                     = var.node_pool_vm_size

--- a/postgres.tf
+++ b/postgres.tf
@@ -3,7 +3,10 @@ resource "azurerm_subnet" "db" {
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [var.db_subnet_address_prefix]
-  service_endpoints    = ["Microsoft.Sql"]
+
+  service_endpoint {
+    service = "Microsoft.Sql"
+  }
 
   delegation {
     name = "fs"
@@ -99,9 +102,8 @@ resource "azurerm_private_dns_zone" "postgres" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "postgres" {
-  name                  = "${var.name}-postgres"
-  resource_group_name   = azurerm_resource_group.this.name
-  private_dns_zone_name = azurerm_private_dns_zone.postgres.name
-  virtual_network_id    = azurerm_virtual_network.this.id
-  registration_enabled  = false
+  name                 = "${var.name}-postgres"
+  private_dns_zone_id  = azurerm_private_dns_zone.postgres.id
+  virtual_network_id   = azurerm_virtual_network.this.id
+  registration_enabled = false
 }

--- a/redis.tf
+++ b/redis.tf
@@ -26,18 +26,16 @@ resource "azurerm_private_dns_zone" "redis" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
-  name                  = "${var.name}-redis"
-  resource_group_name   = azurerm_resource_group.this.name
-  private_dns_zone_name = azurerm_private_dns_zone.redis.name
-  virtual_network_id    = azurerm_virtual_network.this.id
-  registration_enabled  = false
+  name                 = "${var.name}-redis"
+  private_dns_zone_id  = azurerm_private_dns_zone.redis.id
+  virtual_network_id   = azurerm_virtual_network.this.id
+  registration_enabled = false
 }
 
 # Add A record for the Redis cache's private endpoint
 resource "azurerm_private_dns_a_record" "redis" {
   name                = azurerm_redis_cache.this.name
-  zone_name           = azurerm_private_dns_zone.redis.name
-  resource_group_name = azurerm_resource_group.this.name
+  private_dns_zone_id = azurerm_private_dns_zone.redis.id
   ttl                 = 300
   records             = [azurerm_private_endpoint.redis.private_service_connection[0].private_ip_address]
 }

--- a/storage.tf
+++ b/storage.tf
@@ -3,7 +3,10 @@ resource "azurerm_subnet" "storage" {
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [var.storage_subnet_address_prefix]
-  service_endpoints    = ["Microsoft.Storage"]
+
+  service_endpoint {
+    service = "Microsoft.Storage"
+  }
 }
 
 # Associate NAT Gateway with storage subnet
@@ -62,18 +65,16 @@ resource "azurerm_private_dns_zone" "storage" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "storage" {
-  name                  = "${var.name}-storage"
-  resource_group_name   = azurerm_resource_group.this.name
-  private_dns_zone_name = azurerm_private_dns_zone.storage.name
-  virtual_network_id    = azurerm_virtual_network.this.id
-  registration_enabled  = false
+  name                 = "${var.name}-storage"
+  private_dns_zone_id  = azurerm_private_dns_zone.storage.id
+  virtual_network_id   = azurerm_virtual_network.this.id
+  registration_enabled = false
 }
 
 # Add A record for the storage account's private endpoint
 resource "azurerm_private_dns_a_record" "storage" {
   name                = azurerm_storage_account.this.name
-  zone_name           = azurerm_private_dns_zone.storage.name
-  resource_group_name = azurerm_resource_group.this.name
+  private_dns_zone_id = azurerm_private_dns_zone.storage.id
   ttl                 = 300
   records             = [azurerm_private_endpoint.storage.private_service_connection[0].private_ip_address]
 }

--- a/tls.tf
+++ b/tls.tf
@@ -59,18 +59,16 @@ resource "azurerm_private_dns_zone" "key_vault" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "key_vault" {
-  name                  = "${var.name}-keyvault"
-  resource_group_name   = azurerm_resource_group.this.name
-  private_dns_zone_name = azurerm_private_dns_zone.key_vault.name
-  virtual_network_id    = azurerm_virtual_network.this.id
-  registration_enabled  = false
+  name                 = "${var.name}-keyvault"
+  private_dns_zone_id  = azurerm_private_dns_zone.key_vault.id
+  virtual_network_id   = azurerm_virtual_network.this.id
+  registration_enabled = false
 }
 
 # Add A record for the key vault's private endpoint
 resource "azurerm_private_dns_a_record" "key_vault" {
   name                = azurerm_key_vault.this.name
-  zone_name           = azurerm_private_dns_zone.key_vault.name
-  resource_group_name = azurerm_resource_group.this.name
+  private_dns_zone_id = azurerm_private_dns_zone.key_vault.id
   ttl                 = 300
   records             = [azurerm_private_endpoint.key_vault.private_service_connection[0].private_ip_address]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -3,12 +3,8 @@ terraform {
 
   required_providers {
     azurerm = {
-      source = "hashicorp/azurerm"
-      # 4.0 is the floor because rbac_authorization_enabled replaced
-      # enable_rbac_authorization there. azurerm 5.x removed arguments this module still uses
-      # (e.g. azurerm_subnet.service_endpoints, private_dns_zone_name on
-      # azurerm_private_dns_zone_virtual_network_link)
-      version = ">= 4.0.0, < 5.0.0"
+      source  = "hashicorp/azurerm"
+      version = "~> 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Lifts the `< 5.0.0` pin added in #39, which was always a stopgap. The 4.x and 5.x argument styles are **mutually exclusive** — I verified that `private_dns_zone_id` is rejected by 4.81 and `private_dns_zone_name` by 5.x — so there is no way to support both, and the pin locked out anyone whose configuration already uses azurerm 5 for anything else. A module constraint governs the caller's whole configuration, which is why this belongs in the v1 major rather than after it.

Every change below came from reading the azurerm 5 provider schema, not from guesswork — two of my initial assumptions were wrong (the A records want `private_dns_zone_id`, not `zone_id`, and `service_endpoints` was restructured rather than removed).

## Changes

| Resource | 4.x | 5.x |
|---|---|---|
| `azurerm_subnet` (postgres, storage) | `service_endpoints = ["X"]` | repeatable `service_endpoint { service = "X" }` block |
| `azurerm_private_dns_zone_virtual_network_link` (×4) | `resource_group_name` + `private_dns_zone_name` | `private_dns_zone_id` |
| `azurerm_private_dns_a_record` (×3) | `resource_group_name` + `zone_name` | `private_dns_zone_id` |
| `azurerm_kubernetes_cluster` | `node_provisioning_profile` optional | **required** (`min_items = 1`) |

`rbac_authorization_enabled`, also required in 5.x, is already set thanks to the Key Vault RBAC switch in #35 — so that PR was a prerequisite for this one.

On `node_provisioning_profile`: I set `mode = "Manual"`, which keeps the cluster on the manually managed `default_node_pool` this module has always used and is also Azure's default, so it should be a no-op against existing clusters. `Auto` would hand node sizing to node auto-provisioning — a behaviour change nobody asked for.

There were also three A records to migrate, not the one my first scan reported; `terraform validate` stops reporting per-resource once it hits certain errors, so the count only became visible after the first fixes landed.

## What a reviewer should doubt

**Whether the DNS changes are in-place updates or replacements.** This is the one thing I could not settle without real state. What I can say: the schema version is unchanged (`0` in both 4.x and 5.x), so there is no state upgrader involved, and the *value* being expressed does not change — only how it is written — so a refresh should reconcile `private_dns_zone_id` from the API and produce no diff. But if the provider marks that attribute ForceNew and fails to map the old state, the private DNS zone links and A records would be **recreated**, which briefly breaks name resolution for the private endpoints (Postgres, Redis, storage, Key Vault).

So: **run `terraform plan` against an existing deployment before applying**, and if it shows replacements, that belongs in the upgrade notes for the release. A fresh install is unaffected either way.

## Test plan

- [x] `terraform validate` clean on the root module and both examples with azurerm **5.2.0** resolved; `fmt -check` clean.
- [x] Iterated until `validate -json` reported `valid=true, errors=0` — which is how `node_provisioning_profile` surfaced at all.
- [x] Mutual exclusivity of the two syntaxes confirmed by validating each against the other major.
- [ ] No plan or apply against a live subscription.

Out of scope, flagged for later: the kubernetes provider 3.x deprecation warnings (`kubernetes_namespace` / `kubernetes_secret` → the `_v1` names). Different provider, and worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)