### PR TITLE
fix: make the documented quickstart actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,20 +109,20 @@ provider "helm" {
 }
 ```
 
-2. Apply the DNS zone
+2. Apply the DNS zone and the AKS cluster.
 
 ```bash
 terraform init
-terraform apply --target module.langfuse.azurerm_dns_zone.this
+terraform apply --target module.langfuse.azurerm_dns_zone.this --target module.langfuse.azurerm_kubernetes_cluster.this
 ```
 
-3. Set up the Nameserver delegation on your DNS provider, likely using (check on your created DNS zone):
+> [!IMPORTANT]
+> **This two-stage apply is the supported installation flow, not a workaround.** The `kubernetes` and `helm` providers are configured from this module's outputs, so the AKS cluster has to exist before Terraform can plan any Kubernetes or Helm resource. The same applies when you embed this module in a larger configuration: create the cluster in a first targeted apply, or a separate pipeline stage, before applying the full stack.
+
+3. Set up the Nameserver delegation on your DNS provider. The name servers to delegate to are available as an output:
 
 ```bash
-ns1-05.azure-dns.com.
-ns2-05.azure-dns.net.
-ns3-05.azure-dns.org.
-ns4-05.azure-dns.info.
+terraform output dns_name_servers
 ```
 
 4. Apply the full stack:
@@ -303,23 +303,14 @@ The module creates a complete Langfuse stack with the following Azure components
 
 ## Outputs
 
-| Name                       | Description                                         |
-|----------------------------|-----------------------------------------------------|
-| cluster_name               | The name of the AKS cluster                         |
-| cluster_host               | The host of the AKS cluster                         |
-| cluster_client_certificate | The client certificate for the AKS cluster          |
-| cluster_client_key         | The client key for the AKS cluster                  |
-| cluster_ca_certificate     | The CA certificate for the AKS cluster              |
-| postgres_server_name       | The name of the PostgreSQL server                   |
-| postgres_server_fqdn       | The FQDN of the PostgreSQL server                   |
-| postgres_admin_username    | The administrator username of the PostgreSQL server |
-| postgres_admin_password    | The administrator password of the PostgreSQL server |
-| redis_host                 | The hostname of the Redis instance                  |
-| redis_ssl_port             | The SSL port of the Redis instance                  |
-| redis_primary_key          | The primary access key for the Redis instance       |
-| storage_account_name       | The name of the storage account                     |
-| storage_account_key        | The primary access key for the storage account      |
-| dns_name_servers           | The name servers for the DNS zone                   |
+| Name                       | Description                                            |
+|----------------------------|--------------------------------------------------------|
+| cluster_name               | The name of the AKS cluster                            |
+| cluster_host               | The host of the AKS cluster                            |
+| cluster_client_certificate | The client certificate for the AKS cluster             |
+| cluster_client_key         | The client key for the AKS cluster                     |
+| cluster_ca_certificate     | The CA certificate for the AKS cluster                 |
+| dns_name_servers           | Name servers of the DNS zone, for the delegation step  |
 
 ## Support
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,3 +26,8 @@ output "cluster_ca_certificate" {
   value       = azurerm_kubernetes_cluster.this.kube_config[0].cluster_ca_certificate
   sensitive   = true
 }
+
+output "dns_name_servers" {
+  description = "Name servers of the DNS zone, for the delegation step"
+  value       = azurerm_dns_zone.this.name_servers
+}


### PR DESCRIPTION
Pre-flight for the 1.0.0 dry run: two things in the README would break a run that follows it literally, before it ever exercised the module.

## 1. The documented apply flow cannot succeed

Step 2 targeted only `azurerm_dns_zone.this`, then step 4 ran a full apply. But the `kubernetes` and `helm` providers are configured from `module.langfuse.cluster_host` / `cluster_client_certificate` / `cluster_client_key`, which are unknown until the AKS cluster exists — so the full apply cannot plan the Kubernetes and Helm resources.

Step 2 now targets the cluster as well, and the two-stage apply is stated as the supported flow rather than left implicit, matching what the GCP module documents:

```bash
terraform apply --target module.langfuse.azurerm_dns_zone.this --target module.langfuse.azurerm_kubernetes_cluster.this
```

## 2. The nameserver step pointed at an output that did not exist

Step 3 asks you to delegate to the zone's name servers, and the Outputs table advertised `dns_name_servers` — but `outputs.tf` had no such output. Added it, and the step now says `terraform output dns_name_servers`.

While checking that, the Outputs table turned out to list **ten** outputs that do not exist at all: `dns_name_servers`, `postgres_server_name`, `postgres_server_fqdn`, `postgres_admin_username`, `postgres_admin_password`, `redis_host`, `redis_ssl_port`, `redis_primary_key`, `storage_account_name`, `storage_account_key`. The module only ever exposed the five `cluster_*` outputs. I added the one the documented flow needs and dropped the other nine rather than inventing outputs nobody asked for — several of them are secrets that are better read from Key Vault or the portal than surfaced as module outputs.

## Test plan

- [x] `fmt -check` clean, `validate` green, CI on this PR.
- [x] README cross-checked against `variables.tf` and `outputs.tf` programmatically — every remaining name in the Inputs and Outputs tables now exists.
- [ ] The apply flow itself is what the 1.0.0 dry run will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)