### PR TITLE
docs: document UTC database requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ provider "helm" {
 }
 ```
 
+> [!IMPORTANT]
+> PostgreSQL and ClickHouse must both use UTC. Verify both database server time zones before deploying, especially when using external or customized services. See [Troubleshooting self-hosting timezone errors](https://langfuse.com/faq/all/self-hosting-timezone-errors) for verification steps.
+
 2. Apply the DNS zone and the AKS cluster.
 
 ```bash


### PR DESCRIPTION
## Summary

- document that PostgreSQL and ClickHouse must both use UTC
- link to the Langfuse timezone troubleshooting and verification guide

## Checks

- `git diff --check`
- verified the linked troubleshooting page returns HTTP 200

Terraform formatting was not run because this PR only changes `README.md` and Terraform is not installed in the local environment.